### PR TITLE
Update action to use node16 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: "Authentication token to use when connecting to the GitHub API. Token used to search the latest version, defining token reduces propability of rejection when requested github, it can be defined as `secrets.GITHUB_TOKEN`"
     default: ${{ github.token }}
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
The `node12` runtime has been deprecated: 

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This updates the action to use the Node v16 runtime.